### PR TITLE
ETL v0.0.1

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,7 @@ general:
   package_path: "~/chance_of_showers"
   date_fmt: "%Y-%m-%d"
   time_fmt: "%H:%M:%S"
+  fname_datetime_fmt: "%Y-%m-%d-%H-%M-%S"
   local_timezone: "US/Eastern"
 daq:
   # display options

--- a/daq/daq.py
+++ b/daq/daq.py
@@ -43,6 +43,7 @@ polling_period_seconds = cfg["daq"]["polling_period_seconds"]
 date_fmt = cfg["general"]["date_fmt"]
 time_fmt = cfg["general"]["time_fmt"]
 datetime_fmt = f"{date_fmt} {time_fmt}"
+fname_datetime_fmt = cfg["general"]["fname_datetime_fmt"]
 local_timezone_str = cfg["general"]["local_timezone"]
 
 if local_timezone_str not in zoneinfo.available_timezones():
@@ -85,7 +86,7 @@ if 0 < verbosity:
     logger_daq.setLevel(logging.DEBUG)
 
 if log_to_file:
-    log_datetime = datetime.datetime.now(utc_timezone).strftime("%Y-%m-%d-%H-%M-%S")
+    log_datetime = datetime.datetime.now(utc_timezone).strftime(fname_datetime_fmt)
 
     fname_log = f"daq_{log_datetime}.log"
     logging_fh = logging.FileHandler(f"{logs_full_path}/{fname_log}")

--- a/daq/etl.py
+++ b/daq/etl.py
@@ -9,17 +9,14 @@ import glob
 import os
 import traceback
 import zoneinfo
-from typing import TYPE_CHECKING
 
 import hydra
 import polars as pl
-
-if TYPE_CHECKING:
-    from omegaconf import DictConfig
+from omegaconf import DictConfig  # noqa: TC002
 
 
 @hydra.main(version_base=None, config_path="..", config_name="config")
-def etl(cfg: DictConfig) -> None:  # pylint: disable=used-before-assignment,too-many-locals
+def etl(cfg: DictConfig) -> None:  # pylint: disable=too-many-locals
     """Run ETL script.
 
     Args:
@@ -143,7 +140,13 @@ def etl(cfg: DictConfig) -> None:  # pylint: disable=used-before-assignment,too-
 
     os.makedirs(os.path.expanduser(os.path.join(package_path, saved_data)), exist_ok=True)
 
-    parquet_datetime = datetime.datetime.now(utc_timezone).strftime(fname_datetime_fmt)
+    parquet_datetime = (
+        dfpl.select(pl.col("datetime_utc").max())
+        .collect(streaming=True)
+        .item()
+        .strftime(fname_datetime_fmt)
+    )
+
     f_parquet = os.path.expanduser(
         os.path.join(package_path, saved_data, f"etl_data_{parquet_datetime}.parquet")
     )

--- a/poetry.lock
+++ b/poetry.lock
@@ -1861,6 +1861,20 @@ files = [
 ]
 
 [[package]]
+name = "humanize"
+version = "4.7.0"
+description = "Python humanize utilities"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "humanize-4.7.0-py3-none-any.whl", hash = "sha256:df7c429c2d27372b249d3f26eb53b07b166b661326e0325793e0a988082e3889"},
+    {file = "humanize-4.7.0.tar.gz", hash = "sha256:7ca0e43e870981fa684acb5b062deb307218193bca1a01f2b2676479df849b3a"},
+]
+
+[package.extras]
+tests = ["freezegun", "pytest", "pytest-cov"]
+
+[[package]]
 name = "hydra-core"
 version = "1.3.2"
 description = "A framework for elegantly configuring complex applications"
@@ -5080,4 +5094,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "9783a2e2489260f2101298370d5a53c2a3dda3c705055084c178ddc75fe10351"
+content-hash = "f42244e8a035cb7a38e5a9e338cdda1229b48304bb90cd52b03f40ef3e4980f1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 python = "^3.9"
 numpy = "^1.24.3"
 hydra-core = "^1.3.2"
+humanize = "^4.7.0"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.3.3"


### PR DESCRIPTION
# Description
Updated timezones for the ETL script. Use last datapoint as part of output parquet filename.
 
Also added `fname_datetime_fmt` to the config.

# Type of change
- [ ] Bug fix: Non-breaking change which fixes an issue
- [x] New feature: Non-breaking change which adds functionality
- [ ] Breaking change: Fix or feature that would cause existing functionality to not work as expected
- [ ] This change requires a documentation update

# How Has This Been Tested?
Ran locally

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have run the `pre-commit` checks
- [x] The [github `test` action](https://github.com/mepland/chance_of_showers/actions/workflows/test.yml) is passing
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation as required

# Additional Information