### PR TITLE
Wait before starting the web server

### DIFF
--- a/daq/daq.py
+++ b/daq/daq.py
@@ -713,8 +713,21 @@ if thread_daq_loop is None:
 ################################################################################
 # serve index.html
 if display_web:
-    # wait until 0 < len(t_local_str_n_last) to avoid web crashes
     try:
+        # wait until 0 < len(t_local_str_n_last) before serving the website to avoid crashes
+        while len(t_local_str_n_last) < 1:
+            # check len(t_local_str_n_last) every ~ 6 seconds
+            time.sleep(0.1 * averaging_period_seconds)
+            my_print(
+                "Waiting to start web server",
+                logger_level=logging.DEBUG,
+                use_print=False,
+            )
+        my_print(
+            "Starting web server with sio.run()",
+            logger_level=logging.DEBUG,
+            use_print=False,
+        )
         sio.run(
             flask_app,
             port=PORT_NUMBER,


### PR DESCRIPTION
# Description
Wait until we have a mean pressure value before starting the web server.

Hopefully this will help avoid intermittent crashes in the flask code that happen when the DAQ has just been started.

# Type of change
- [x] Bug fix: Non-breaking change which fixes an issue
- [ ] New feature: Non-breaking change which adds functionality
- [ ] Breaking change: Fix or feature that would cause existing functionality to not work as expected
- [ ] This change requires a documentation update

# How Has This Been Tested?
`daq.py` runs locally. Refreshing the web page after the service is started no longer causes a crash.

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have run the `pre-commit` checks
- [x] The [github `test` action](https://github.com/mepland/chance_of_showers/actions/workflows/test.yml) is passing
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation as required

# Additional Information