### PR TITLE
DAQ Restore Pre-allocation

### DIFF
--- a/daq/daq.py
+++ b/daq/daq.py
@@ -98,6 +98,11 @@ def daq(  # noqa: C901 # pylint: disable=too-many-statements, too-many-locals
     N_POLLING: Final = int(np.ceil(AVERAGING_PERIOD_SECONDS / POLLING_PERIOD_SECONDS))
     # pylint: enable=invalid-name
 
+    # Defining these arrays here first saves memory
+    polling_pressure_samples = np.empty(N_POLLING)
+    polling_pressure_samples.fill(np.nan)
+    polling_flow_samples = np.zeros(N_POLLING)  # noqa: F841 # pylint: disable=unused-variable
+
     ################################################################################
     # Lock script, avoid launching duplicates
     sys.path.append(str(pathlib.Path.cwd().parent))
@@ -616,7 +621,6 @@ def daq(  # noqa: C901 # pylint: disable=too-many-statements, too-many-locals
             i_polling = 0
             # reset variables
             had_flow = 0  # avoid sticking high if we lose pressure while flowing
-            polling_pressure_samples = np.empty(N_POLLING)
             polling_pressure_samples.fill(np.nan)
             polling_flow_samples = np.zeros(N_POLLING)
             while running_daq_loop and t_stop - t_start < datetime.timedelta(

--- a/daq/logs/pre_allocation_test_results.md
+++ b/daq/logs/pre_allocation_test_results.md
@@ -1,0 +1,130 @@
+# DAQ Pre-allocation Tests
+Below are the tails of log files for complete weeks, without any web logging messages.
+
+## Pre-allocated Results
+`daq_2023-11-12-05-00-16.log` and prior use pre-allocated array variables, and have less memory usage.
+
+```bash
+==> daq_2023-10-01-04-00-16.log <==
+2023-10-07 23:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 229.7 MB, Percent: 15.80%
+2023-10-07 23:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 229.6 MB, Percent: 15.80%
+2023-10-08 00:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 229.5 MB, Percent: 15.80%
+2023-10-08 00:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 230.6 MB, Percent: 15.80%
+2023-10-08 01:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 231.1 MB, Percent: 15.90%
+2023-10-08 01:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 231.0 MB, Percent: 15.90%
+2023-10-08 02:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 230.8 MB, Percent: 15.80%
+2023-10-08 02:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 231.0 MB, Percent: 15.90%
+2023-10-08 03:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 231.6 MB, Percent: 15.90%
+2023-10-08 03:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 230.7 MB, Percent: 15.80%
+
+==> daq_2023-10-08-04-00-16.log <==
+2023-10-14 23:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 228.1 MB, Percent: 15.70%
+2023-10-14 23:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 230.2 MB, Percent: 15.80%
+2023-10-15 00:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 228.6 MB, Percent: 15.70%
+2023-10-15 00:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 229.4 MB, Percent: 15.80%
+2023-10-15 01:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 228.4 MB, Percent: 15.70%
+2023-10-15 01:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 229.9 MB, Percent: 15.80%
+2023-10-15 02:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 229.6 MB, Percent: 15.80%
+2023-10-15 02:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 229.8 MB, Percent: 15.80%
+2023-10-15 03:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 229.6 MB, Percent: 15.80%
+2023-10-15 03:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 231.4 MB, Percent: 15.90%
+
+==> daq_2023-10-22-04-00-16.log <==
+2023-10-28 23:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 232.0 MB, Percent: 15.90%
+2023-10-28 23:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 230.3 MB, Percent: 15.80%
+2023-10-29 00:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 233.0 MB, Percent: 16.00%
+2023-10-29 00:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 231.9 MB, Percent: 15.90%
+2023-10-29 01:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 231.6 MB, Percent: 15.90%
+2023-10-29 01:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 233.3 MB, Percent: 16.00%
+2023-10-29 02:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 233.1 MB, Percent: 16.00%
+2023-10-29 02:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 233.6 MB, Percent: 16.00%
+2023-10-29 03:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 233.6 MB, Percent: 16.00%
+2023-10-29 03:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 234.1 MB, Percent: 16.00%
+
+==> daq_2023-10-29-04-00-16.log <==
+2023-11-04 17:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 228.1 MB, Percent: 15.70%
+2023-11-04 18:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 228.1 MB, Percent: 15.70%
+2023-11-04 18:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 228.4 MB, Percent: 15.70%
+2023-11-04 19:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 228.4 MB, Percent: 15.70%
+2023-11-04 19:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 230.9 MB, Percent: 15.80%
+2023-11-04 20:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 229.4 MB, Percent: 15.80%
+2023-11-04 20:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 228.8 MB, Percent: 15.70%
+2023-11-04 21:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 230.3 MB, Percent: 15.80%
+2023-11-04 21:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 229.0 MB, Percent: 15.70%
+2023-11-04 22:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 231.1 MB, Percent: 15.90%
+
+==> daq_2023-11-05-04-00-16.log <==
+2023-11-12 00:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 232.7 MB, Percent: 15.90%
+2023-11-12 00:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 232.2 MB, Percent: 15.90%
+2023-11-12 01:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 233.7 MB, Percent: 16.00%
+2023-11-12 01:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 233.8 MB, Percent: 16.00%
+2023-11-12 02:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 232.7 MB, Percent: 15.90%
+2023-11-12 02:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 233.9 MB, Percent: 16.00%
+2023-11-12 03:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 232.9 MB, Percent: 15.90%
+2023-11-12 03:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 234.9 MB, Percent: 16.00%
+2023-11-12 04:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 233.0 MB, Percent: 15.90%
+2023-11-12 04:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 235.1 MB, Percent: 16.00%
+```
+
+## NOT Pre-allocated Results
+`daq_2023-11-12-19-05-30.log` to `daq_2023-12-17-05-00-17.log` have no pre-allocation, and more memory usage.
+This concludes the test, restoring pre-allocation code.
+
+```bash
+==> daq_2023-11-14-04-49-21.log <==
+2023-11-19 00:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 291.6 MB, Percent: 19.10%
+2023-11-19 00:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 291.0 MB, Percent: 19.00%
+2023-11-19 01:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 292.0 MB, Percent: 19.10%
+2023-11-19 01:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 292.4 MB, Percent: 19.10%
+2023-11-19 02:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 292.4 MB, Percent: 19.10%
+2023-11-19 02:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 293.1 MB, Percent: 19.10%
+2023-11-19 03:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 294.0 MB, Percent: 19.20%
+2023-11-19 03:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 292.7 MB, Percent: 19.10%
+2023-11-19 04:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 293.1 MB, Percent: 19.20%
+2023-11-19 04:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 293.9 MB, Percent: 19.20%
+
+==> daq_2023-11-19-05-00-16.log <==
+2023-11-24 12:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 268.4 MB, Percent: 17.70%
+2023-11-24 12:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 270.2 MB, Percent: 17.80%
+2023-11-24 13:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 269.5 MB, Percent: 17.80%
+2023-11-24 13:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 269.4 MB, Percent: 17.80%
+2023-11-24 14:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 270.6 MB, Percent: 17.90%
+2023-11-24 14:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 268.5 MB, Percent: 17.70%
+2023-11-24 15:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 269.9 MB, Percent: 17.80%
+2023-11-24 15:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 271.7 MB, Percent: 17.90%
+2023-11-24 16:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 271.4 MB, Percent: 17.90%
+2023-11-24 16:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 270.0 MB, Percent: 17.80%
+
+==> daq_2023-11-26-05-05-39.log <==
+2023-12-03 00:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 287.4 MB, Percent: 18.80%
+2023-12-03 00:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 287.8 MB, Percent: 18.80%
+2023-12-03 01:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 287.0 MB, Percent: 18.70%
+2023-12-03 01:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 288.1 MB, Percent: 18.80%
+2023-12-03 02:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 287.2 MB, Percent: 18.80%
+2023-12-03 02:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 287.2 MB, Percent: 18.80%
+2023-12-03 03:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 287.9 MB, Percent: 18.80%
+2023-12-03 03:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 288.0 MB, Percent: 18.80%
+2023-12-03 04:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 290.3 MB, Percent: 18.90%
+2023-12-03 04:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 289.5 MB, Percent: 18.90%
+
+==> daq_2023-12-03-05-00-17.log <==
+2023-12-10 01:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 288.0 MB, Percent: 18.70%
+2023-12-10 02:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 288.1 MB, Percent: 18.70%
+2023-12-10 02:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 288.1 MB, Percent: 18.70%
+2023-12-10 03:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 287.8 MB, Percent: 18.70%
+2023-12-10 03:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 287.3 MB, Percent: 18.70%
+2023-12-10 04:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 288.8 MB, Percent: 18.70%
+2023-12-10 04:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 288.8 MB, Percent: 18.70%
+
+==> daq_2023-12-10-05-00-17.log <==
+2023-12-17 00:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 287.2 MB, Percent: 18.80%
+2023-12-17 00:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 285.4 MB, Percent: 18.70%
+2023-12-17 01:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 286.4 MB, Percent: 18.80%
+2023-12-17 01:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 286.3 MB, Percent: 18.80%
+2023-12-17 02:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 285.2 MB, Percent: 18.70%
+2023-12-17 02:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 286.8 MB, Percent: 18.80%
+2023-12-17 03:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 287.3 MB, Percent: 18.80%
+2023-12-17 03:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 287.7 MB, Percent: 18.80%
+2023-12-17 04:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 288.0 MB, Percent: 18.80%
+2023-12-17 04:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 287.5 MB, Percent: 18.80%
+```

--- a/daq/logs/pre_allocation_test_results.md
+++ b/daq/logs/pre_allocation_test_results.md
@@ -4,6 +4,7 @@ Below are the tails of log files for complete weeks, without any web logging mes
 ## Pre-allocated Results
 `daq_2023-11-12-05-00-16.log` and prior use pre-allocated array variables, and have less memory usage.
 
+<!-- markdownlint-disable MD013 -->
 ```bash
 ==> daq_2023-10-01-04-00-16.log <==
 2023-10-07 23:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 229.7 MB, Percent: 15.80%
@@ -65,11 +66,14 @@ Below are the tails of log files for complete weeks, without any web logging mes
 2023-11-12 04:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 233.0 MB, Percent: 15.90%
 2023-11-12 04:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.7 GB, Used: 235.1 MB, Percent: 16.00%
 ```
+<!-- markdownlint-enable MD013 -->
 
 ## NOT Pre-allocated Results
-`daq_2023-11-12-19-05-30.log` to `daq_2023-12-17-05-00-17.log` have no pre-allocation, and more memory usage.
+`daq_2023-11-12-19-05-30.log` to `daq_2023-12-17-05-00-17.log`
+have no pre-allocation, and more memory usage.
 This concludes the test, restoring pre-allocation code.
 
+<!-- markdownlint-disable MD013 -->
 ```bash
 ==> daq_2023-11-14-04-49-21.log <==
 2023-11-19 00:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 291.6 MB, Percent: 19.10%
@@ -128,3 +132,4 @@ This concludes the test, restoring pre-allocation code.
 2023-12-17 04:01:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 288.0 MB, Percent: 18.80%
 2023-12-17 04:31:00 UTC [daq     ] [Thread-6 (] [INFO    ] RAM Available: 1.6 GB, Used: 287.5 MB, Percent: 18.80%
 ```
+<!-- markdownlint-enable MD013 -->


### PR DESCRIPTION
# Description
Restore the pre-allocation of `numpy` arrays in DAQ script. Reverts https://github.com/mepland/chance_of_showers/pull/25 after memory usage testing. See pre_allocation_test_results.md for full results.

# Type of change
* [ ] Bug fix: Non-breaking change which fixes an issue
* [x] New feature: Non-breaking change which adds functionality
* [ ] Breaking change: Fix or feature that would cause existing functionality to not work as expected
* [ ] This change requires a documentation update

# How Has This Been Tested?
Runs locally.

# Checklist
* [x] I have performed a self-review of my own code
* [x] I have run the `pre-commit` checks
* [x] The [github `tests` action](https://github.com/mepland/chance_of_showers/actions/workflows/tests.yml) is passing <!-- markdownlint-disable-line MD013 --->
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have updated the documentation as required